### PR TITLE
fix: load coverage artifact directly by name [PLAT-1979]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,7 @@ inputs:
     required: false
   coverage-artifact-name:
     description: >
-      'Name of coverage artifact (useful for multiple artifacts). NOTE: Each workflow run has it's own artifacts, so name only has to be unique compared to orther artifacts in the single workflow run.'
-    default: 'coverage'
+      'Name of coverage artifact (useful for multiple artifacts). NOTE: Each workflow run has it's own artifacts, so name only has to be unique compared to other artifacts in the single workflow run.'
     required: false
   upload-workflow-filename:
     description: 'Filename of workflow which uploaded coverage artifact'

--- a/dist/index.js
+++ b/dist/index.js
@@ -13896,109 +13896,10 @@ function getOctokitInstance() {
     return (0, github_1.getOctokit)(myToken);
 }
 /**
- * @param arr - Array to sort
- * @returns Sorted array
- */
-function sortByCreatedAt(arr) {
-    return arr.sort((x, y) => {
-        if (!x.created_at)
-            return 1; // use y if x doesn't have timestamp
-        if (!y.created_at)
-            return -1; // use x if y doesn't have timestamp
-        return new Date(y.created_at).getTime() - new Date(x.created_at).getTime();
-    });
-}
-/**
- * @param branch - Branch name
- * @param lastCommitSha - SHA of last commit
- */
-async function getWorkflow(branch, lastCommitSha) {
-    const { rest } = getOctokitInstance();
-    // Load workflow runs
-    const { data: runsData } = await rest.actions.listWorkflowRuns({
-        owner: github_1.context.repo.owner,
-        repo: github_1.context.repo.repo,
-        branch,
-        // per_page: 3,
-        event: 'pull_request',
-        workflow_id: core.getInput('upload-workflow-filename'),
-    });
-    if (runsData.total_count === 0) {
-        throw new Error(`No workflow runs found for branch "${branch}" and commit "${lastCommitSha}"`);
-    }
-    core.info(`Workflow runs loaded: ${runsData.total_count}`);
-    // Filter workflow runs to the one with matching commit sha
-    const matchedWorkflow = runsData.workflow_runs.find((workflowRun) => workflowRun.head_sha === lastCommitSha);
-    if (!matchedWorkflow) {
-        // Sort artifacts by the most recent created_at date
-        const [mostRecentWorkflow] = sortByCreatedAt(runsData.workflow_runs);
-        core.info(`Workflow run with commit "${lastCommitSha}" not found falling back to most recent workflow run on branch "${branch}"`);
-        core.info(`Most recent workflow run on branch "${branch}": ${JSON.stringify({
-            id: mostRecentWorkflow.id,
-            sha: mostRecentWorkflow.head_sha,
-            created_at: mostRecentWorkflow.created_at,
-        })}`);
-        return mostRecentWorkflow;
-    }
-    return matchedWorkflow;
-}
-/**
- * @param owner - Repo owner
- * @param repo - Github repo name
- * @returns Coverage artifact
- */
-async function getCoverageArtifactFromWorkflow() {
-    const { ref: branch, sha: lastCommitSha } = github_1.context?.payload?.pull_request?.head || {};
-    core.info(`Branch and last commit sha loaded: ${JSON.stringify({
-        branch,
-        lastCommitSha,
-    })}`);
-    const matchedWorkflow = await getWorkflow(branch, lastCommitSha);
-    const { id, status } = matchedWorkflow;
-    core.info(`Workflow loaded, looking for artifacts ${JSON.stringify({
-        id,
-        status,
-    })} `);
-    if (status !== 'completed') {
-        core.warning('Associated verify workflow did not complete successfully, artifact may not be found');
-    }
-    // Load artifacts associated with the loaded workflow run
-    const { rest } = getOctokitInstance();
-    const { data: artifactsData } = await rest.actions.listWorkflowRunArtifacts({
-        owner: github_1.context.repo.owner,
-        repo: github_1.context.repo.repo,
-        run_id: id,
-    });
-    if (artifactsData.total_count === 0) {
-        core.warning(`No artifacts found for workflow with id "${id}"`);
-    }
-    const coverageKey = core.getInput('coverage-artifact-name');
-    core.info(`Workflow artifacts loaded, looking for artifact with name "${coverageKey}"`);
-    // Filter artifacts to coverage-$sha
-    const matchArtifact = artifactsData.artifacts.find((artifact) => artifact?.name === coverageKey);
-    if (!matchArtifact) {
-        core.info(`Artifact with name "${coverageKey}" not found, falling back to first artifact`);
-        // Sort artifacts by the most recent created_at date
-        const [mostRecentArtifact] = artifactsData.artifacts.sort((x, y) => {
-            if (!x.created_at)
-                return 1; // use y if x doesn't have timestamp
-            if (!y.created_at)
-                return -1; // use x if y doesn't have timestamp
-            return (new Date(y.created_at).getTime() - new Date(x.created_at).getTime());
-        });
-        return mostRecentArtifact;
-    }
-    core.info(`Matching coverage artifact found ${matchArtifact?.name}`);
-    return matchArtifact;
-}
-/**
- * @param owner - Repo owner
- * @param repo - Github repo name
  * @returns Coverage artifact
  */
 async function getCoverageArtifactByName() {
     const { ref: branch, sha: lastCommitSha } = github_1.context?.payload?.pull_request?.head || {};
-    core.info('New artifact lookup flow');
     core.info(`Branch and last commit sha loaded: ${JSON.stringify({
         branch,
         lastCommitSha,
@@ -14012,7 +13913,7 @@ async function getCoverageArtifactByName() {
         repo: github_1.context.repo.repo,
     }, (response, done) => {
         if (response.data.find((artifact) => artifact?.name === coverageKey)) {
-            core.info('Found matching artifact - stopping pagination');
+            core.debug('Found matching artifact - stopping pagination');
             done();
         }
         return response.data;

--- a/dist/index.js
+++ b/dist/index.js
@@ -13998,26 +13998,30 @@ async function getCoverageArtifactFromWorkflow() {
  */
 async function getCoverageArtifactByName() {
     const { ref: branch, sha: lastCommitSha } = github_1.context?.payload?.pull_request?.head || {};
+    core.info('New artifact lookup flow');
     core.info(`Branch and last commit sha loaded: ${JSON.stringify({
         branch,
         lastCommitSha,
     })}`);
-    // Load artifacts associated with the loaded workflow run
-    const { rest } = getOctokitInstance();
-    const { data: artifactsData } = await rest.actions.listArtifactsForRepo({
-        owner: github_1.context.repo.owner,
-        repo: github_1.context.repo.repo,
-        per_page: 100,
-    });
-    if (artifactsData.total_count === 0) {
-        core.warning(`No artifacts found for repo "${github_1.context.repo.repo}"`);
-    }
     const coverageKey = core.getInput('coverage-artifact-name') || `coverage-${lastCommitSha}`;
     core.info(`Workflow artifacts loaded, looking for artifact with name "${coverageKey}"`);
+    const { rest, paginate } = getOctokitInstance();
+    // Load all artifacts, paginating until matching name is found
+    const artifacts = await paginate(rest.actions.listArtifactsForRepo, {
+        owner: github_1.context.repo.owner,
+        repo: github_1.context.repo.repo,
+    }, (response, done) => {
+        if (response.data.find((artifact) => artifact?.name === coverageKey)) {
+            core.info('Found matching artifact - stopping pagination');
+            done();
+        }
+        return response.data;
+    });
+    core.info(`Artifacts loaded: ${artifacts.length}`);
     // Filter artifacts to coverage-$sha
-    const matchArtifact = artifactsData.artifacts.find((artifact) => artifact?.name === coverageKey);
+    const matchArtifact = artifacts.find((artifact) => artifact?.name === coverageKey);
     if (!matchArtifact) {
-        throw new Error(`Artifact with name "${coverageKey}" not found, falling back to first artifact`);
+        throw new Error(`Artifact with name "${coverageKey}" not found`);
     }
     core.info(`Matching coverage artifact found ${matchArtifact?.name}`);
     return matchArtifact;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -12,135 +12,11 @@ function getOctokitInstance() {
 }
 
 /**
- * @param arr - Array to sort
- * @returns Sorted array
- */
-function sortByCreatedAt<T extends { created_at: string }>(arr: T[]): T[] {
-  return arr.sort((x, y) => {
-    if (!x.created_at) return 1; // use y if x doesn't have timestamp
-    if (!y.created_at) return -1; // use x if y doesn't have timestamp
-    return new Date(y.created_at).getTime() - new Date(x.created_at).getTime();
-  });
-}
-
-/**
- * @param branch - Branch name
- * @param lastCommitSha - SHA of last commit
- */
-async function getWorkflow(branch: string, lastCommitSha: string) {
-  const { rest } = getOctokitInstance();
-  // Load workflow runs
-  const { data: runsData } = await rest.actions.listWorkflowRuns({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    branch,
-    // per_page: 3,
-    event: 'pull_request',
-    workflow_id: core.getInput('upload-workflow-filename'),
-  });
-  if (runsData.total_count === 0) {
-    throw new Error(
-      `No workflow runs found for branch "${branch}" and commit "${lastCommitSha}"`,
-    );
-  }
-  core.info(`Workflow runs loaded: ${runsData.total_count}`);
-
-  // Filter workflow runs to the one with matching commit sha
-  const matchedWorkflow = runsData.workflow_runs.find(
-    (workflowRun) => workflowRun.head_sha === lastCommitSha,
-  );
-  if (!matchedWorkflow) {
-    // Sort artifacts by the most recent created_at date
-    const [mostRecentWorkflow] = sortByCreatedAt(runsData.workflow_runs);
-    core.info(
-      `Workflow run with commit "${lastCommitSha}" not found falling back to most recent workflow run on branch "${branch}"`,
-    );
-    core.info(
-      `Most recent workflow run on branch "${branch}": ${JSON.stringify({
-        id: mostRecentWorkflow.id,
-        sha: mostRecentWorkflow.head_sha,
-        created_at: mostRecentWorkflow.created_at,
-      })}`,
-    );
-    return mostRecentWorkflow;
-  }
-  return matchedWorkflow;
-}
-
-/**
- * @param owner - Repo owner
- * @param repo - Github repo name
- * @returns Coverage artifact
- */
-async function getCoverageArtifactFromWorkflow() {
-  const { ref: branch, sha: lastCommitSha } =
-    context?.payload?.pull_request?.head || {};
-  core.info(
-    `Branch and last commit sha loaded: ${JSON.stringify({
-      branch,
-      lastCommitSha,
-    })}`,
-  );
-  const matchedWorkflow = await getWorkflow(branch, lastCommitSha);
-  const { id, status } = matchedWorkflow;
-
-  core.info(
-    `Workflow loaded, looking for artifacts ${JSON.stringify({
-      id,
-      status,
-    })} `,
-  );
-  if (status !== 'completed') {
-    core.warning(
-      'Associated verify workflow did not complete successfully, artifact may not be found',
-    );
-  }
-
-  // Load artifacts associated with the loaded workflow run
-  const { rest } = getOctokitInstance();
-  const { data: artifactsData } = await rest.actions.listWorkflowRunArtifacts({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    run_id: id,
-  });
-  if (artifactsData.total_count === 0) {
-    core.warning(`No artifacts found for workflow with id "${id}"`);
-  }
-  const coverageKey = core.getInput('coverage-artifact-name');
-  core.info(
-    `Workflow artifacts loaded, looking for artifact with name "${coverageKey}"`,
-  );
-  // Filter artifacts to coverage-$sha
-  const matchArtifact = artifactsData.artifacts.find(
-    (artifact) => artifact?.name === coverageKey,
-  );
-  if (!matchArtifact) {
-    core.info(
-      `Artifact with name "${coverageKey}" not found, falling back to first artifact`,
-    );
-    // Sort artifacts by the most recent created_at date
-    const [mostRecentArtifact] = artifactsData.artifacts.sort((x, y) => {
-      if (!x.created_at) return 1; // use y if x doesn't have timestamp
-      if (!y.created_at) return -1; // use x if y doesn't have timestamp
-      return (
-        new Date(y.created_at).getTime() - new Date(x.created_at).getTime()
-      );
-    });
-    return mostRecentArtifact;
-  }
-  core.info(`Matching coverage artifact found ${matchArtifact?.name}`);
-  return matchArtifact;
-}
-
-/**
- * @param owner - Repo owner
- * @param repo - Github repo name
  * @returns Coverage artifact
  */
 async function getCoverageArtifactByName() {
   const { ref: branch, sha: lastCommitSha } =
     context?.payload?.pull_request?.head || {};
-  core.info('New artifact lookup flow');
   core.info(
     `Branch and last commit sha loaded: ${JSON.stringify({
       branch,
@@ -163,7 +39,7 @@ async function getCoverageArtifactByName() {
     },
     (response, done) => {
       if (response.data.find((artifact) => artifact?.name === coverageKey)) {
-        core.info('Found matching artifact - stopping pagination');
+        core.debug('Found matching artifact - stopping pagination');
         done();
       }
       return response.data;


### PR DESCRIPTION
## Description
Before we were loading the workflow which triggered the PR, then the run id, then the associated artifact - now we are just looking up all artifacts by name (using pagination even though artifact is usually found in first page)

## Screenshots (if appropriate)
