### PR TITLE
fix: set default path for coverage file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14088,6 +14088,8 @@ async function downloadAndWriteArtifact(coveragePath) {
  *
  */
 async function run() {
+    core.debug(`lcov-path input: ${core.getInput('lcov-path')}`);
+    // TODO: Handle a path passed which already contains workspace
     const coveragePath = `${process.env.GITHUB_WORKSPACE}/${core.getInput('lcov-path') || 'coverage/lcov.info'}`;
     // Use coverage file if it exists (Next builds), otherwise download artifact and write to disk (Node builds)
     if ((0, fs_1.existsSync)(coveragePath)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -14082,19 +14082,19 @@ async function downloadAndWriteArtifact(coveragePath) {
     // Unzip
     core.debug(`Unziping artifact file at path "${downloadPath}"`);
     await (0, exec_1.exec)('unzip', [downloadPath, '-d', coverageFolder]);
-    core.debug('Successfully unzipped artifact file');
+    core.info('Successfully downloaded and unzipped coverage artifact');
 }
 /**
  *
  */
 async function run() {
-    const coveragePath = `${process.env.GITHUB_WORKSPACE}/${core.getInput('lcov-path')}`;
+    const coveragePath = `${process.env.GITHUB_WORKSPACE}/${core.getInput('lcov-path') || 'coverage/lcov.info'}`;
     // Use coverage file if it exists (Next builds), otherwise download artifact and write to disk (Node builds)
     if ((0, fs_1.existsSync)(coveragePath)) {
-        core.debug(`Coverage file already exists at path "${coveragePath}"`);
+        core.info(`Using existing coverage file at path "${coveragePath}"`);
     }
     else {
-        core.debug(`Coverage file does not already exist at path "${coveragePath}", downloading from artifact`);
+        core.info(`Coverage file does not already exist at path "${coveragePath}", downloading from artifact`);
         await downloadAndWriteArtifact(coveragePath);
     }
     // Report to Coveralls as base

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,21 +30,21 @@ async function downloadAndWriteArtifact(coveragePath: string) {
   // Unzip
   core.debug(`Unziping artifact file at path "${downloadPath}"`);
   await exec('unzip', [downloadPath, '-d', coverageFolder]);
-  core.debug('Successfully unzipped artifact file');
+  core.info('Successfully downloaded and unzipped coverage artifact');
 }
 
 /**
  *
  */
 export async function run() {
-  const coveragePath = `${process.env.GITHUB_WORKSPACE}/${core.getInput(
-    'lcov-path',
-  )}`;
+  const coveragePath = `${process.env.GITHUB_WORKSPACE}/${
+    core.getInput('lcov-path') || 'coverage/lcov.info'
+  }`;
   // Use coverage file if it exists (Next builds), otherwise download artifact and write to disk (Node builds)
   if (existsSync(coveragePath)) {
-    core.debug(`Coverage file already exists at path "${coveragePath}"`);
+    core.info(`Using existing coverage file at path "${coveragePath}"`);
   } else {
-    core.debug(
+    core.info(
       `Coverage file does not already exist at path "${coveragePath}", downloading from artifact`,
     );
     await downloadAndWriteArtifact(coveragePath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,8 @@ async function downloadAndWriteArtifact(coveragePath: string) {
  *
  */
 export async function run() {
+  core.debug(`lcov-path input: ${core.getInput('lcov-path')}`);
+  // TODO: Handle a path passed which already contains workspace
   const coveragePath = `${process.env.GITHUB_WORKSPACE}/${
     core.getInput('lcov-path') || 'coverage/lcov.info'
   }`;


### PR DESCRIPTION
## Description
* Sets default path to coverage file (since default does not appear to be picked up by action input)
* Improves logging to include more info instead of debug

## Screenshots (if appropriate)
